### PR TITLE
add support for chained visual filters

### DIFF
--- a/src/services/entity/EntityService.ts
+++ b/src/services/entity/EntityService.ts
@@ -185,6 +185,18 @@ export default class EntityService {
             return visualToggles;
         }
 
+        if (visualToggles[fld] === false) {
+            if (!rules[fld]["__null__"]) {
+                return visualToggles;
+            }
+
+            for (const hideFld of rules[fld]["__null__"]['hide']) {
+                visualToggles[hideFld] = false;
+            }
+
+            return visualToggles;
+        }
+
         const normalizedValue = typeof value === 'boolean'
             ? (value + 0)
             : value;


### PR DESCRIPTION
When a field hides another field that also has visualFilters configuration, it will apply its visualFilters as if it would have "__null__" value.