### PR TITLE
Added RouteMapItem.filterValues

### DIFF
--- a/src/components/List/List.tsx
+++ b/src/components/List/List.tsx
@@ -82,6 +82,19 @@ const List = function (props: ListProps) {
             Object.values(match.params).pop() as string
         );
     }
+
+    const filterValues: Array<string> = [];
+    const entityFilterValues = currentRoute?.filterValues || {};
+    for (const idx in entityFilterValues) {
+
+        const value = entityFilterValues[idx];
+        const param = value !== null
+            ? `${idx}=${entityFilterValues[idx]}`
+            : `${idx}`;
+
+        filterValues.push(param);
+    }
+
     const filterByStr = filterBy.join('[]=');
     const reqQuerystring = currentQueryParams.join('&');
     const [prevReqQuerystring, setPrevReqQuerystring] = useState<string | null>(null); //38
@@ -150,9 +163,9 @@ const List = function (props: ListProps) {
 
             let reqPath = path;
             if (currentQueryParams.length) {
-                reqPath = path + '?' + encodeURI([...currentQueryParams, filterByStr].join('&'));
-            } else if (filterByStr) {
-                reqPath = path + '?' + encodeURI(filterByStr);
+                reqPath = path + '?' + encodeURI([...currentQueryParams, ...filterValues, filterByStr].join('&'));
+            } else if (filterByStr || filterValues) {
+                reqPath = path + '?' + encodeURI([...filterValues, filterByStr].join('&'));
             }
 
             let itemsPerPage = currentQueryParams.find(
@@ -176,7 +189,7 @@ const List = function (props: ListProps) {
                 orderBy = encodeURI(
                     `_order[${entityService.getOrderBy()}]=${entityService.getOrderDirection()}`
                 );
-                
+
                 const glue = reqPath.indexOf('?') !== -1
                     ? '&'
                     : '?';

--- a/src/components/layout/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/layout/Breadcrumbs/Breadcrumbs.tsx
@@ -1,15 +1,15 @@
 import { CircularProgress, styled, Tooltip } from '@mui/material';
 import MuiBreadcrumbs from '@mui/material/Breadcrumbs';
-import { useStoreState } from '../../../store';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
+import { filterRouteMapPath } from '../../../router/findRoute';
+import { EntityItem, isActionItem, RouteMap } from '../../../router/routeMapParser';
 import _ from '../../../services/translations/translate';
+import { useStoreState } from '../../../store';
 import {
   StyledCollapsedBreadcrumbsLink, StyledCollapsedBreadcrumbsNavigateNextIcon,
   StyledCollapsedBreadcrumbsTypography,
   StyledHomeIcon
 } from './Breadcrumbs.styles';
-import { filterRouteMapPath } from '../../../router/findRoute';
-import { RouteMap, RouteMapItem, EntityItem, isActionItem } from '../../../router/routeMapParser';
 
 type RouterProps = RouteComponentProps<any>;
 type BreadcrumbsProps = RouterProps & {

--- a/src/entities/EntityInterface.ts
+++ b/src/entities/EntityInterface.ts
@@ -100,6 +100,7 @@ export default interface EntityInterface {
     iden: string,
     title: string | JSX.Element,
     path: string,
+    localPath?: string,
     columns: Array<string>,
     properties: PartialPropertyList,
     toStr: (row: EntityValues) => string,

--- a/src/router/routeMapParser.ts
+++ b/src/router/routeMapParser.ts
@@ -7,6 +7,7 @@ export interface EntityItem {
     entity: EntityInterface,
     route?: string,
     filterBy?: string,
+    filterValues?: Record<string, string | number | boolean | null>,
     fixedValues?: Record<string, string | number | boolean>,
     children?: Array<RouteMapItem>,
 }
@@ -88,9 +89,11 @@ const RouteMapItemParser = <T extends RouteMapItem = RouteMapItem>(item: T, rout
 
             const entity = (item as EntityItem).entity;
 
+            const path = entity.localPath || entity.path;
+
             return RouteMapItemParser(
                 subitem,
-                `${routPrefix}${entity.path}/:parent_id_${depth}`,
+                `${routPrefix}${path}/:parent_id_${depth}`,
                 depth + 1
             );
         });
@@ -101,9 +104,11 @@ const RouteMapItemParser = <T extends RouteMapItem = RouteMapItem>(item: T, rout
         }
     }
 
+    const path = item.entity?.localPath || item.entity?.path;
+
     return {
         ...item,
-        route: routPrefix + item.entity?.path
+        route: routPrefix + path
     };
 }
 


### PR DESCRIPTION
Allows to inject filter conditions into Lists. For instance:

```
        {
          entity: entities.Fax,
          children: [
            {
              entity: entities.FaxesOut,
              filterBy: 'fax',
              filterValues: {
                'type[exact]': 'Out',
              },
            },
          ],
       }
```