### PR TITLE
Simplified API

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@irontec/ivoz-ui",
-  "version": "0.8.11",
+  "version": "0.9.0",
   "description": "UI library used in ivozprovider",
   "license": "GPL-3.0",
   "main": "dist/index.js",

--- a/src/entities/DefaultEntityBehavior.tsx
+++ b/src/entities/DefaultEntityBehavior.tsx
@@ -14,6 +14,7 @@ import autoForeignKeyResolver from './DefaultEntityBehavior/AutoForeignKeyResolv
 import autoSelectOptions from './DefaultEntityBehavior/AutoSelectOptions';
 import ListDecorator from './DefaultEntityBehavior/ListDecorator';
 import foreignKeyResolver from './DefaultEntityBehavior/ForeignKeyResolver';
+import foreignKeyGetter from './DefaultEntityBehavior/ForeignKeyGetter';
 import filterFieldsetGroups, { FieldsetGroups } from './DefaultEntityBehavior/FilterFieldsetGroups';
 import Form, {
     PropertyFkChoices, EntityFormType, FkChoices, NullablePropertyFkChoices, EntityFormProps
@@ -21,10 +22,6 @@ import Form, {
 import View from './DefaultEntityBehavior/View';
 
 export const initialValues = {};
-
-export const foreignKeyGetter = async (): Promise<any> => {
-    return {};
-};
 
 export const columns = [];
 
@@ -106,6 +103,7 @@ export {
     autoSelectOptions,
     ListDecorator,
     foreignKeyResolver,
+    foreignKeyGetter,
     filterFieldsetGroups,
     Form
 }

--- a/src/entities/DefaultEntityBehavior/AutoForeignKeyResolver.ts
+++ b/src/entities/DefaultEntityBehavior/AutoForeignKeyResolver.ts
@@ -2,12 +2,18 @@ import { EntityValues } from '../../services/entity/EntityService';
 import { foreignKeyResolverProps } from '../EntityInterface';
 import _ from '../../services/translations/translate';
 import genericForeignKeyResolver from '../../services/api/genericForeigKeyResolver';
+import { StoreContainer } from '../../store';
 
 const autoForeignKeyResolver = (
     props: foreignKeyResolverProps
 ): Array<Promise<EntityValues | EntityValues[]>> => {
 
-    const { data, cancelToken, entityService, entities, skip } = props;
+    const { data, cancelToken, entityService, skip } = props;
+    let { entities } = props;
+    if (!entities) {
+        entities = StoreContainer.store.getState().entities.entities;
+    }
+
     if (!entities) {
         return [];
     }

--- a/src/entities/DefaultEntityBehavior/AutoSelectOptions.ts
+++ b/src/entities/DefaultEntityBehavior/AutoSelectOptions.ts
@@ -1,10 +1,11 @@
 import EntityService from '../../services/entity/EntityService';
 import { CancelToken } from 'axios';
 import { EntityList } from 'router/parseRoutes';
+import { StoreContainer } from '../../store';
 
 type AutoSelectOptionsArgs = {
     cancelToken?: CancelToken,
-    entities: EntityList,
+    entities?: EntityList, // Deprecated
     entityService: EntityService,
     skip?: string[],
     response: Record<string, Array<unknown>> | any,
@@ -14,12 +15,18 @@ export const autoSelectOptions = (
     props: AutoSelectOptionsArgs
 ): Array<Promise<unknown>> => {
 
-    const { cancelToken, response, entityService, entities } = props;
-    const skip = props.skip || [];
+    const { cancelToken, response, entityService } = props;
+    let { entities } = props;
+
+    if (!entities) {
+        entities = StoreContainer.store.getState().entities.entities;
+    }
 
     if (!entities) {
         return [];
     }
+
+    const skip = props.skip || [];
 
     const promises = [];
     const fkProperties = entityService?.getFkProperties();

--- a/src/entities/DefaultEntityBehavior/ForeignKeyGetter.ts
+++ b/src/entities/DefaultEntityBehavior/ForeignKeyGetter.ts
@@ -1,0 +1,25 @@
+import { ForeignKeyGetterType } from "../EntityInterface";
+import { StoreContainer } from "../../store";
+import autoSelectOptions from "./AutoSelectOptions";
+
+const foreignKeyGetter: ForeignKeyGetterType = async ({
+    cancelToken,
+    entityService,
+  }): Promise<any> => {
+    const response: Record<string, Array<string | number> | undefined> = {};
+
+    const entities = StoreContainer.store.getState().entities.entities;
+    const promises = autoSelectOptions({
+      entities,
+      entityService,
+      cancelToken,
+      response,
+    });
+
+    await Promise.all(promises);
+
+    return response;
+};
+
+
+export default foreignKeyGetter;

--- a/src/services/form/Field/Autocomplete.styles.tsx
+++ b/src/services/form/Field/Autocomplete.styles.tsx
@@ -1,6 +1,5 @@
 
 import { styled } from '@mui/material';
-import { Theme } from '@mui/material';
 import Autocomplete from './Autocomplete';
 
 const StyledAutocomplete = styled(

--- a/src/services/form/FormFieldFactory.tsx
+++ b/src/services/form/FormFieldFactory.tsx
@@ -96,7 +96,7 @@ export default class FormFieldFactory {
             );
         }
 
-        if (!fileUpload && ((property as FkProperty).$ref || multiSelect)) {
+        if (!fileUpload && (isPropertyFk(property) || multiSelect)) {
 
             if (!choices) {
                 return (

--- a/src/store/entities.ts
+++ b/src/store/entities.ts
@@ -1,0 +1,23 @@
+import { action, Action } from 'easy-peasy';
+import { EntityList } from "../router/parseRoutes";
+
+interface EntitiesState {
+  entities: EntityList,
+}
+
+interface EntitiesActions {
+  setEntities: Action<EntitiesState, EntityList>,
+}
+
+export type EntitiesStore = EntitiesActions & EntitiesState;
+
+const entities: EntitiesStore = {
+  entities: {},
+  setEntities: action<EntitiesState, EntityList>((state, entities) => {
+    state.entities = {
+       ...entities
+    };
+  }),
+};
+
+export default entities;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -5,6 +5,7 @@ import spec, { SpecStore } from './apiSpec';
 import api, { ApiStore } from './api';
 import route, { RouteStore } from './route';
 import list, { ListStore } from './list';
+import entities, { EntitiesStore } from './entities';
 
 export interface IvozStore {
   auth: AuthStore,
@@ -12,6 +13,7 @@ export interface IvozStore {
   api: ApiStore,
   route: RouteStore,
   list: ListStore,
+  entities: EntitiesStore,
 }
 
 export const storeModel: IvozStore = {
@@ -20,6 +22,7 @@ export const storeModel: IvozStore = {
   api,
   route,
   list,
+  entities,
 }
 
 StoreContainer.store = createStore<IvozStore>(storeModel);


### PR DESCRIPTION
Entities must now be set into the store:

```
const entities: EntityList = {];
const storeActions = store.getActions();
storeActions.entities.setEntities(entities);
```

This allows to simplify or power up AutoForeignKeyResolver, AutoSelectOptions and ForeignKeyGetter services.