### PR TITLE
Add linter to CI pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,3 +24,10 @@ jobs:
       with:
         cmd: build
         dir: 'library'
+    - uses: borales/actions-yarn@v4
+      with:
+        cmd: lint
+        dir: 'library'
+    - name: Check file changes
+      run: |
+        git diff --exit-code


### PR DESCRIPTION
Add linter step to build CI pipeline

I've avoid using test-lint script because it also builds the library again