### PR TITLE
Fixed missing seconds on date-time filters

### DIFF
--- a/library/package.json
+++ b/library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@irontec/ivoz-ui",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "UI library used in ivozprovider",
   "license": "GPL-3.0",
   "main": "index.js",

--- a/library/src/services/form/Field/TextField/TextField.tsx
+++ b/library/src/services/form/Field/TextField/TextField.tsx
@@ -52,6 +52,12 @@ export const TextField = (props: TextFieldProps) => {
   const labelId = `${name}-label`;
   const maxRows = multiline ? 6 : undefined;
 
+  const fixDateTime = (value: string) => {
+    const haveMissingSeconds = value.length === 16;
+
+    return haveMissingSeconds ? value.concat(':00') : value;
+  };
+
   type passThroughPropsType = Partial<OutlinedInputProps>;
   const passThroughProps: passThroughPropsType = {};
 
@@ -63,6 +69,19 @@ export const TextField = (props: TextFieldProps) => {
   if (onClick) {
     passThroughProps.onClick = onClick;
   }
+
+  passThroughProps.onChange = (event) => {
+    const { target } = event;
+
+    if (type === 'datetime-local') {
+      const fixedDate = fixDateTime(target.value);
+      event.target = { ...target, ...{ value: fixedDate } };
+    }
+
+    if (onChange) {
+      onChange(event);
+    }
+  };
 
   return (
     <FormControl
@@ -99,7 +118,6 @@ export const TextField = (props: TextFieldProps) => {
         defaultValue={defaultValue}
         value={value}
         disabled={disabled}
-        onChange={onChange}
         onBlur={onBlur}
         error={error}
         className='input-field'


### PR DESCRIPTION
Fixed an issue with date time filters. The date time picker component omits seconds when its value is zero.