### PR TITLE
Disable multi-select and checkboxes when the Remove Double Check option is active

### DIFF
--- a/library/package.json
+++ b/library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@irontec/ivoz-ui",
-  "version": "1.7.11",
+  "version": "1.7.12",
   "description": "UI library used in ivozprovider",
   "license": "GPL-3.0",
   "main": "index.js",

--- a/library/src/components/List/Content/Card/ContentCardBody.tsx
+++ b/library/src/components/List/Content/Card/ContentCardBody.tsx
@@ -49,7 +49,9 @@ const ContentCardBody = (props: ContentCardProps): JSX.Element => {
     .filter((action) => action.multiselect || action.global)
     .map((item) => item.action as MultiSelectFunctionComponent);
 
-  const multiselect = acl.delete === true || multiselectActions.length > 0;
+  const multiselect =
+    (entity.deleteDoubleCheck !== true && acl.delete === true) ||
+    multiselectActions.length > 0;
 
   const updateRouteMapItem: RouteMapItem = {
     entity,

--- a/library/src/components/List/Content/ListContentHeader.tsx
+++ b/library/src/components/List/Content/ListContentHeader.tsx
@@ -55,7 +55,9 @@ const ListContentHeader = (
   } = props;
 
   const entity = entityService.getEntity();
-  const disableMultiDelete = entity.disableMultiDelete || false;
+  const disableMultiDelete =
+    entity.deleteDoubleCheck === true || entity.disableMultiDelete === true;
+
   const acl = entityService.getAcls(parentRow);
 
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);

--- a/library/src/components/List/Content/Table/ContentTable.tsx
+++ b/library/src/components/List/Content/Table/ContentTable.tsx
@@ -76,7 +76,9 @@ const ContentTable = (props: ContentTableProps): JSX.Element => {
 
   const parentRow = useStoreState((state) => state.list.parentRow);
   const acl = entityService.getAcls(parentRow);
-  const multiselect = acl.delete === true || multiselectActions.length > 0;
+  const multiselect =
+    (entity.deleteDoubleCheck !== true && acl.delete === true) ||
+    multiselectActions.length > 0;
 
   const deleteMapItem: RouteMapItem = {
     entity,


### PR DESCRIPTION
This pull request includes a version bump for the `@irontec/ivoz-ui` library and introduces logic changes to handle the `deleteDoubleCheck` property in multiple components. These changes enhance the functionality and safety of delete operations.

### Version Update:
* [`library/package.json`](diffhunk://#diff-76b51473f12b34302cfe8d46957088121cedec7cca5523780d4cddb2c19fc4aeL3-R3): Updated the version from `1.7.11` to `1.7.12`.

### Logic Changes for `deleteDoubleCheck` Property:
* [`library/src/components/List/Content/Card/ContentCardBody.tsx`](diffhunk://#diff-e8db01781440b2f89393ac645ca026a489c0f2ea3185cbaf14e2d601ee56c315L52-R54): Modified the `multiselect` logic to include a check for `entity.deleteDoubleCheck`, ensuring it is not `true` before allowing delete actions.
* [`library/src/components/List/Content/ListContentHeader.tsx`](diffhunk://#diff-463821f4653e1acd3e0b1e8c700ccc368d72ccfa7a6433660c43e7769ca2ff2dL58-R60): Updated the `disableMultiDelete` logic to disable multi-delete if `entity.deleteDoubleCheck` is `true`.
* [`library/src/components/List/Content/Table/ContentTable.tsx`](diffhunk://#diff-ea44002296788749d892e41792825e3f59ca58479e9f202901b10800b924acfdL79-R81): Adjusted the `multiselect` logic to integrate the `entity.deleteDoubleCheck` property, similar to the change in `ContentCardBody`.